### PR TITLE
Fix plugin when installed via cordova command line

### DIFF
--- a/www/canOpen.js
+++ b/www/canOpen.js
@@ -1,19 +1,14 @@
-(function(window) {
-	var cordovaRef = window.Phonegap || window.Cordova || window.cordova;
-
-	window.CanOpen = function(app, callback) {
-		cordovaRef.exec(
-			// Success callback
-			callback,
-			// Failure callback
-			function(err) { console.log('Missing app scheme.');},
-			// Native Class Name 
-			"CanOpen",
-			// Name of method in native class.
-			"appCanOpen",
-			// array of args to pass to method.
-			[app]
-		);
-	};
-
-})(window);
+module.exports = function CanOpen(app, callback) {
+	cordovaRef.exec(
+		// Success callback
+		callback,
+		// Failure callback
+		function(err) { console.log('Missing app scheme.');},
+		// Native Class Name 
+		"CanOpen",
+		// Name of method in native class.
+		"appCanOpen",
+		// array of args to pass to method.
+		[app]
+	);
+};

--- a/www/canOpen.js
+++ b/www/canOpen.js
@@ -1,5 +1,5 @@
 module.exports = function CanOpen(app, callback) {
-	cordovaRef.exec(
+	cordova.exec(
 		// Success callback
 		callback,
 		// Failure callback


### PR DESCRIPTION
I tried installing this plugin using the `cordova plugin add ...` (cordova version 3.5) and found that `window.CanOpen` was not a function that could be called. This pull request addresses this.
